### PR TITLE
Add the time tracking and Madgraph update

### DIFF
--- a/experiments/benchmarks/benchmark_madgraph/exec_benchmark.sh
+++ b/experiments/benchmarks/benchmark_madgraph/exec_benchmark.sh
@@ -9,9 +9,9 @@ full_path=$(realpath $0)
 dir_path=$(dirname $full_path)
 benchmark_path=$(dirname $dir_path)
 ./install_mg.sh
-export LD_LIBRARY_PATH=$dir_path/MG5_aMC_v2_8_2/HEPTools/lhapdf6_py3/lib
+export LD_LIBRARY_PATH=$dir_path/MG5_aMC_v2_8_3_2/HEPTools/lhapdf6_py3/lib
 if [ -d "fortran_output" ]; then rm -Rf ./fortran_output; fi
-python3 MG5_aMC_v2_8_2/bin/mg5_aMC --logging=ERROR --file=nis_script_dd.mg5 2>&1> mg5_log.txt 2>&1
+python3 MG5_aMC_v2_8_3_2/bin/mg5_aMC --logging=ERROR --file=nis_script_dd.mg5 2>&1> mg5_log.txt 2>&1
 cd ./fortran_output/SubProcesses
 for f in *; 
     do   if [ -d "$f" ]; 
@@ -23,7 +23,7 @@ for f in *;
         cp $dir_path/fortran_output/Cards/param_card.dat $benchmark_path/utils/integrands/mg/$f/param 
         cp {nexternal.inc,pmass.inc,param.log} $benchmark_path/utils/integrands/mg/$f/param 
         cp matrix2py.so $benchmark_path/utils/integrands/mg/$f
-        python3 $benchmark_path/benchmark_madgraph.py --process $f --pdf_type NNPDF23_nlo_as_0119   --pdf_dir $dir_path/MG5_aMC_v2_8_2/HEPTools/lhapdf6_py3/share/LHAPDF --db madgraph_$f --experiment_name madgraph_$f --config $benchmark_path/benchmark_config_examples/madgraph_grid_config.yaml --debug --lhapdf_dir $dir_path/MG5_aMC_v2_8_2/HEPTools/lhapdf6_py3/lib/python3.*/site-packages --pdf
+        python3 $benchmark_path/benchmark_madgraph.py --process $f --pdf_type NNPDF23_nlo_as_0119   --pdf_dir $dir_path/MG5_aMC_v2_8_3_2/HEPTools/lhapdf6_py3/share/LHAPDF --db madgraph_$f --experiment_name madgraph_$f --config $benchmark_path/benchmark_config_examples/madgraph_grid_config.yaml --debug --lhapdf_dir $dir_path/MG5_aMC_v2_8_3_2/HEPTools/lhapdf6_py3/lib/python3.*/site-packages --pdf
         mv madgraph_$f $dir_path/
         cd ..;
     fi

--- a/experiments/benchmarks/benchmark_madgraph/install_mg.sh
+++ b/experiments/benchmarks/benchmark_madgraph/install_mg.sh
@@ -2,14 +2,14 @@
 
 
 #This file downloawds MG5 and LHAPDF so that the benchmarking example can be run without an existing installation of MG5
-if [ ! -d MG5_aMC_v2_8_2 ] 
+if [ ! -d MG5_aMC_v2_8_3_2 ] 
 then
 echo "MG5 installation started"
-wget https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v2.8.2.tar.gz
-tar -xf MG5_aMC_v2.8.2.tar.gz
+wget https://launchpad.net/mg5amcnlo/2.0/2.8.x/+download/MG5_aMC_v2.8.3.2.tar.gz
+tar -xf MG5_aMC_v2.8.3.2.tar.gz
 echo "MG5 installation succeded. LHAPDF installation started"
-python3 MG5_aMC_v2_8_2/bin/mg5_aMC --logging=ERROR --file=lhapdf_install.mg5 2>&1> lhapdf_install_log.txt 2>&1
-cd MG5_aMC_v2_8_2/HEPTools/lhapdf6_py3/share/LHAPDF
+python3.8 MG5_aMC_v2_8_3_2/bin/mg5_aMC --logging=ERROR --file=lhapdf_install.mg5 2>&1> lhapdf_install_log.txt 2>&1
+cd MG5_aMC_v2_8_3_2/HEPTools/lhapdf6_py3/share/LHAPDF
 wget http://lhapdfsets.web.cern.ch/lhapdfsets/current/NNPDF23_nlo_as_0119.tar.gz
 tar -xf NNPDF23_nlo_as_0119.tar.gz
 echo "LHAPDF installation succeeded"

--- a/experiments/benchmarks/utils/benchmark/vegas_benchmarks.py
+++ b/experiments/benchmarks/utils/benchmark/vegas_benchmarks.py
@@ -36,10 +36,12 @@ class VegasBenchmarker(Benchmarker):
         integrator = Integrator(f=f, d=d, device=device, **integrator_args)
 
         vintegrator = vegas.Integrator([[0, 1]] * d, max_nhcube=1)
-
+        start_time_zunis=datetime.datetime.utcnow()
         integrator_result = evaluate_integral_integrator(f, integrator, n_batch=n_batch, keep_history=keep_history)
+        switch_time=datetime.datetime.utcnow()
         vegas_result = evaluate_integral_vegas(vf, vintegrator, n_batch=n_batch,
                                                n_batch_survey=integrator_args["n_points_survey"])
+        end_time_vegas=datetime.datetime.utcnow()
         flat_result = evaluate_integral_flat(f, d, n_batch=n_batch, device=device)
 
         result = compare_integral_result(integrator_result, vegas_result, sigma_cutoff=3, keep_history=keep_history)
@@ -53,6 +55,8 @@ class VegasBenchmarker(Benchmarker):
         result.update(integrand_params)
 
         result["d"] = d
+        result["time_zunis"]=(time_switch-start_time_zunis).total_seconds()
+        result["time_vegas"]=(end_time_vegas-time_switch).total_seconds()
 
         return result, integrator
 

--- a/experiments/benchmarks/utils/benchmark/vegas_benchmarks.py
+++ b/experiments/benchmarks/utils/benchmark/vegas_benchmarks.py
@@ -2,6 +2,7 @@ import logging
 
 import torch
 import vegas
+import datetime
 from dictwrapper import NestedMapping
 
 from utils.benchmark.benchmarker import Benchmarker, GridBenchmarker, RandomHyperparameterBenchmarker, \
@@ -55,8 +56,8 @@ class VegasBenchmarker(Benchmarker):
         result.update(integrand_params)
 
         result["d"] = d
-        result["time_zunis"]=(time_switch-start_time_zunis).total_seconds()
-        result["time_vegas"]=(end_time_vegas-time_switch).total_seconds()
+        result["time_zunis"]=(switch_time-start_time_zunis).total_seconds()
+        result["time_vegas"]=(end_time_vegas-switch_time).total_seconds()
 
         return result, integrator
 


### PR DESCRIPTION
I added the changes I introduced in order to track the time consumption for training and evaluation of zunis and vegas during hyperparameter optimization. For each experiment, both times are saved in the database.
Additionally, I updated the download link to the latest version of Madgraph.