### PR TITLE
Added unweighting efficiency tracking in vegas benchmarking

### DIFF
--- a/experiments/benchmarks/utils/benchmark/vegas_benchmarks.py
+++ b/experiments/benchmarks/utils/benchmark/vegas_benchmarks.py
@@ -94,7 +94,7 @@ class VegasBenchmarker(Benchmarker):
             try:
                 with open(vegas_checkpoint_path, "xb") as vegas_checkpoint_file:
                     pickle.dump(vintegrator, vegas_checkpoint_file)
-            except "FileExistsError" as e:
+            except FileExistsError as e:
                 logger.error("Error while saving VEGAS checkpoint: File exists")
                 logger.error(vegas_checkpoint_path)
                 logger.error(e)
@@ -117,7 +117,7 @@ class VegasBenchmarker(Benchmarker):
             result_vs_exact = compare_integral_result(integrator_result, exact_result, sigma_cutoff=3)
 
         target_keys = ['target', 'target_std', 'sigma_cutoff', 'sigmas_off', 'percent_difference', 'variance_ratio',
-                       'match']
+                       'match', 'target_unweighting_eff', 'unweighting_eff_ratio']
 
         for key in target_keys:
             result_vs_flat["flat_" + key] = result_vs_flat.pop(key)
@@ -125,7 +125,7 @@ class VegasBenchmarker(Benchmarker):
             if isinstance(f, KnownIntegrand):
                 result_vs_exact["exact_" + key] = result_vs_exact.pop(key)
 
-        common_keys = ["value", "value_std"]
+        common_keys = ["value", "value_std", 'value_unweighting_eff']
 
         for key in common_keys:
             result_vs_vegas.pop(key)

--- a/experiments/benchmarks/utils/integral_validation.py
+++ b/experiments/benchmarks/utils/integral_validation.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import logging
 
-from utils.integrals import mean_std_integrand
+from utils.integrals import compute_mc_statistics
 from utils.record import ComparisonRecord, EvaluationRecord
 from utils.integrands.abstract import KnownIntegrand
 from utils.vanity import sigma
@@ -61,13 +61,14 @@ def evaluate_integral(integrand, sampler, n_batch=10000, keep_history=False):
     """
 
     _, px, fx = sampler.sample(integrand, n_batch=n_batch)
-    integral, std = mean_std_integrand(fx, px)
+    integral, std, unweighting_efficiency = compute_mc_statistics(fx, px)
     unc = std / sqrt(n_batch)
 
     logger.info(f"Estimated result: {integral:.2e}+/-{unc:.2e}")
     result = EvaluationRecord(
         value=integral,
         value_std=unc,
+        unweighting_eff=unweighting_efficiency
     )
 
     if keep_history:
@@ -176,9 +177,17 @@ def compare_integral_result(result1, result2, sigma_cutoff=2, keep_history=False
     """
     integral1 = result1["value"]
     unc1 = result1["value_std"]
+    try:
+        unweight_eff1 = result1['unweighting_eff']
+    except KeyError:
+        unweight_eff1 = float('nan')
 
     integral2 = result2["value"]
     unc2 = result2["value_std"]
+    try:
+        unweight_eff2 = result2['unweighting_eff']
+    except KeyError:
+        unweight_eff2 = float('nan')
 
     absum = abs(integral1) + abs(integral2)
     absdiff = abs(integral1 - integral2)
@@ -202,6 +211,9 @@ def compare_integral_result(result1, result2, sigma_cutoff=2, keep_history=False
         percent_difference=100 * percent_diff,
         variance_ratio=(unc2 / unc1) ** 2,
         match=sigmas <= sigma_cutoff,
+        value_unweighting_eff=unweight_eff1,
+        target_unweighting_eff=unweight_eff2,
+        unweighting_eff_ratio=(unweight_eff1/unweight_eff2)
     )
 
     if keep_history:

--- a/experiments/benchmarks/utils/integrals.py
+++ b/experiments/benchmarks/utils/integrals.py
@@ -1,9 +1,10 @@
 """Facilities for evaluating integrals from a batch of points"""
 import torch
 
-def mean_std_integrand(fx, px):
-    """Compute the expectation value and the standard deviation of a function evaluated
-    on a sample of points taken from a known distribution.
+
+def compute_mc_statistics(fx, px):
+    """Compute the relevant Monte Carlo evaluation statistics expectation for a function evaluated
+    on a sample of points taken from a known distribution: integral value, integral value standard deviation, unweighting efficiency
 
     Parameters
     ----------
@@ -20,5 +21,12 @@ def mean_std_integrand(fx, px):
     assert len(px.shape) == 1
     assert fx.shape == fx.shape
 
-    v, m = torch.var_mean(fx / px)
-    return m.detach().item(), v.detach().sqrt().item()
+    weights = (fx / px)
+    int_var, int_mean = torch.var_mean(weights)
+    int_mean = int_mean.detach().item()
+    int_std = int_var.sqrt().detach().item()
+
+    unweighting_efficiency = int_mean / weights.max().item()
+    unweighting_efficiency = unweighting_efficiency
+
+    return int_mean, int_std, unweighting_efficiency


### PR DESCRIPTION
This implements measurements of unweighting efficiency in the VEGAS benchmarker. New keys are added to the results:

- `vegas_unweighting_eff_ratio` and `flat_unweighting_eff_ratio` (high is good: `zunis_eff / vegas_eff`)
- `value_unweighting_eff`, `vegas_target_unweighting_eff`, and `flat_target_unweighting_eff`, the raw efficiencies.

And a pretty plot because these are nice
![image](https://user-images.githubusercontent.com/12328649/132471560-78ea5f2d-fa33-4473-8859-580a94235b0f.png)
